### PR TITLE
Fix strong reference cycle

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -95,7 +95,7 @@ public class TagListView: UIView {
         }
     }
     
-    @IBOutlet public var delegate: TagListViewDelegate?
+    @IBOutlet public weak var delegate: TagListViewDelegate?
     
     var tagViews: [TagView] = []
     var tagViewHeight: CGFloat = 0

--- a/TagListViewDemo/ViewController.swift
+++ b/TagListViewDemo/ViewController.swift
@@ -24,8 +24,8 @@ class ViewController: UIViewController, TagListViewDelegate {
         tagListView.addTag("To Be Removed")
         tagListView.addTag("Quark Shell")
         tagListView.removeTag("To Be Removed")
-        tagListView.addTag("On tap will be removed").onTap = { tagView in
-            self.tagListView.removeTagView(tagView)
+        tagListView.addTag("On tap will be removed").onTap = { [weak self] tagView in
+            self?.tagListView.removeTagView(tagView)
         }
         
         let tagView = tagListView.addTag("gray")


### PR DESCRIPTION
consider

```swift
class ViewController: UIViewController, TagListViewDelegate {

    @IBOutlet weak var tagListView: TagListView!
    
    override func viewDidLoad() {
        super.viewDidLoad()
        tagListView.delegate = self
    }
    
    deinit{
        print("ViewController has been deinited.")
    }
    
}
```

`deinit` will never be called because it keep strong reference cycle. to fix this use weak reference on delegate object.