### PR TITLE
Enable tags to reach the tag view's right edge

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -178,7 +178,7 @@ public class TagListView: UIView {
             tagView.frame.size = tagView.intrinsicContentSize()
             tagViewHeight = tagView.frame.height
             
-            if currentRowTagCount == 0 || currentRowWidth + tagView.frame.width + marginX > frame.width {
+            if currentRowTagCount == 0 || currentRowWidth + tagView.frame.width > frame.width {
                 currentRow += 1
                 currentRowWidth = 0
                 currentRowTagCount = 0


### PR DESCRIPTION
Currently, when calculating whether to start a new row, the margin on the right of the tag is taken into consideration. This causes a situation where if the tag list view is, for example, 200 px wide, and the horizontal padding is 10, the first tag will start at X=0, but the last tag of the row will end at a maximum of X=190. Adding the extra margin in the calculation isn't needed and causes loss of available space in the tag list view.

See attached screenshots (tag list view is blue, row view is yellow, tag is purple
Before change:
<img width="844" alt="before" src="https://cloud.githubusercontent.com/assets/3057530/13477113/85f76f68-e0d3-11e5-9d4b-59795a7cf867.png">

After change:
<img width="844" alt="after" src="https://cloud.githubusercontent.com/assets/3057530/13477118/8b89d16e-e0d3-11e5-94e5-16258420d3e5.png">
