### PR TITLE
Add support for UIAppearance proxy

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -303,6 +303,12 @@ public class TagListView: UIView {
         tagView.addTarget(self, action: #selector(tagPressed(_:)), forControlEvents: .TouchUpInside)
         tagView.removeButton.addTarget(self, action: #selector(removeButtonPressed(_:)), forControlEvents: .TouchUpInside)
         
+        // Deselect all tags except this one
+        tagView.onLongPress = { this in
+            for tag in self.tagViews {
+                tag.selected = (tag == this)
+            }
+        }
         return addTagView(tagView)
     }
     

--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -16,7 +16,7 @@ import UIKit
 @IBDesignable
 public class TagListView: UIView {
     
-    @IBInspectable public var textColor: UIColor = UIColor.whiteColor() {
+    @IBInspectable public dynamic var textColor: UIColor = UIColor.whiteColor() {
         didSet {
             for tagView in tagViews {
                 tagView.textColor = textColor
@@ -24,7 +24,7 @@ public class TagListView: UIView {
         }
     }
     
-    @IBInspectable public var selectedTextColor: UIColor = UIColor.whiteColor() {
+    @IBInspectable public dynamic var selectedTextColor: UIColor = UIColor.whiteColor() {
         didSet {
             for tagView in tagViews {
                 tagView.selectedTextColor = selectedTextColor
@@ -32,7 +32,7 @@ public class TagListView: UIView {
         }
     }
     
-    @IBInspectable public var tagBackgroundColor: UIColor = UIColor.grayColor() {
+    @IBInspectable public dynamic var tagBackgroundColor: UIColor = UIColor.grayColor() {
         didSet {
             for tagView in tagViews {
                 tagView.tagBackgroundColor = tagBackgroundColor
@@ -40,7 +40,7 @@ public class TagListView: UIView {
         }
     }
     
-    @IBInspectable public var tagHighlightedBackgroundColor: UIColor? {
+    @IBInspectable public dynamic var tagHighlightedBackgroundColor: UIColor? {
         didSet {
             for tagView in tagViews {
                 tagView.highlightedBackgroundColor = tagHighlightedBackgroundColor
@@ -48,7 +48,7 @@ public class TagListView: UIView {
         }
     }
     
-    @IBInspectable public var tagSelectedBackgroundColor: UIColor? {
+    @IBInspectable public dynamic var tagSelectedBackgroundColor: UIColor? {
         didSet {
             for tagView in tagViews {
                 tagView.selectedBackgroundColor = tagSelectedBackgroundColor
@@ -56,14 +56,14 @@ public class TagListView: UIView {
         }
     }
     
-    @IBInspectable public var cornerRadius: CGFloat = 0 {
+    @IBInspectable public dynamic var cornerRadius: CGFloat = 0 {
         didSet {
             for tagView in tagViews {
                 tagView.cornerRadius = cornerRadius
             }
         }
     }
-    @IBInspectable public var borderWidth: CGFloat = 0 {
+    @IBInspectable public dynamic var borderWidth: CGFloat = 0 {
         didSet {
             for tagView in tagViews {
                 tagView.borderWidth = borderWidth
@@ -71,7 +71,7 @@ public class TagListView: UIView {
         }
     }
     
-    @IBInspectable public var borderColor: UIColor? {
+    @IBInspectable public dynamic var borderColor: UIColor? {
         didSet {
             for tagView in tagViews {
                 tagView.borderColor = borderColor
@@ -79,7 +79,7 @@ public class TagListView: UIView {
         }
     }
     
-    @IBInspectable public var selectedBorderColor: UIColor? {
+    @IBInspectable public dynamic var selectedBorderColor: UIColor? {
         didSet {
             for tagView in tagViews {
                 tagView.selectedBorderColor = selectedBorderColor
@@ -87,7 +87,7 @@ public class TagListView: UIView {
         }
     }
     
-    @IBInspectable public var paddingY: CGFloat = 2 {
+    @IBInspectable public dynamic var paddingY: CGFloat = 2 {
         didSet {
             for tagView in tagViews {
                 tagView.paddingY = paddingY
@@ -95,7 +95,7 @@ public class TagListView: UIView {
             rearrangeViews()
         }
     }
-    @IBInspectable public var paddingX: CGFloat = 5 {
+    @IBInspectable public dynamic var paddingX: CGFloat = 5 {
         didSet {
             for tagView in tagViews {
                 tagView.paddingX = paddingX
@@ -103,12 +103,12 @@ public class TagListView: UIView {
             rearrangeViews()
         }
     }
-    @IBInspectable public var marginY: CGFloat = 2 {
+    @IBInspectable public dynamic var marginY: CGFloat = 2 {
         didSet {
             rearrangeViews()
         }
     }
-    @IBInspectable public var marginX: CGFloat = 5 {
+    @IBInspectable public dynamic var marginX: CGFloat = 5 {
         didSet {
             rearrangeViews()
         }
@@ -119,33 +119,33 @@ public class TagListView: UIView {
         case Center
         case Right
     }
-    @IBInspectable public var alignment: Alignment = .Left {
+    @IBInspectable public dynamic var alignment: Alignment = .Left {
         didSet {
             rearrangeViews()
         }
     }
-    @IBInspectable public var shadowColor: UIColor = UIColor.whiteColor() {
+    @IBInspectable public dynamic var shadowColor: UIColor = UIColor.whiteColor() {
         didSet {
             rearrangeViews()
         }
     }
-    @IBInspectable public var shadowRadius: CGFloat = 0 {
+    @IBInspectable public dynamic var shadowRadius: CGFloat = 0 {
         didSet {
             rearrangeViews()
         }
     }
-    @IBInspectable public var shadowOffset: CGSize = CGSizeZero {
+    @IBInspectable public dynamic var shadowOffset: CGSize = CGSizeZero {
         didSet {
             rearrangeViews()
         }
     }
-    @IBInspectable public var shadowOpacity: Float = 0 {
+    @IBInspectable public dynamic var shadowOpacity: Float = 0 {
         didSet {
             rearrangeViews()
         }
     }
     
-    @IBInspectable public var enableRemoveButton: Bool = false {
+    @IBInspectable public dynamic var enableRemoveButton: Bool = false {
         didSet {
             for tagView in tagViews {
                 tagView.enableRemoveButton = enableRemoveButton
@@ -154,7 +154,7 @@ public class TagListView: UIView {
         }
     }
     
-    @IBInspectable public var removeButtonIconSize: CGFloat = 12 {
+    @IBInspectable public dynamic var removeButtonIconSize: CGFloat = 12 {
         didSet {
             for tagView in tagViews {
                 tagView.removeButtonIconSize = removeButtonIconSize
@@ -162,7 +162,7 @@ public class TagListView: UIView {
             rearrangeViews()
         }
     }
-    @IBInspectable public var removeIconLineWidth: CGFloat = 1 {
+    @IBInspectable public dynamic var removeIconLineWidth: CGFloat = 1 {
         didSet {
             for tagView in tagViews {
                 tagView.removeIconLineWidth = removeIconLineWidth
@@ -171,7 +171,7 @@ public class TagListView: UIView {
         }
     }
     
-    @IBInspectable public var removeIconLineColor: UIColor = UIColor.whiteColor().colorWithAlphaComponent(0.54) {
+    @IBInspectable public dynamic var removeIconLineColor: UIColor = UIColor.whiteColor().colorWithAlphaComponent(0.54) {
         didSet {
             for tagView in tagViews {
                 tagView.removeIconLineColor = removeIconLineColor
@@ -180,7 +180,7 @@ public class TagListView: UIView {
         }
     }
     
-    public var textFont: UIFont = UIFont.systemFontOfSize(12) {
+    public dynamic var textFont: UIFont = UIFont.systemFontOfSize(12) {
         didSet {
             for tagView in tagViews {
                 tagView.textFont = textFont
@@ -303,12 +303,6 @@ public class TagListView: UIView {
         tagView.addTarget(self, action: #selector(tagPressed(_:)), forControlEvents: .TouchUpInside)
         tagView.removeButton.addTarget(self, action: #selector(removeButtonPressed(_:)), forControlEvents: .TouchUpInside)
         
-        // Deselect all tags except this one
-        tagView.onLongPress = { this in
-            for tag in self.tagViews {
-                tag.selected = (tag == this)
-            }
-        }
         return addTagView(tagView)
     }
     

--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -119,7 +119,7 @@ public class TagListView: UIView {
         case Center
         case Right
     }
-    @IBInspectable public dynamic var alignment: Alignment = .Left {
+    @IBInspectable public var alignment: Alignment = .Left {
         didSet {
             rearrangeViews()
         }


### PR DESCRIPTION
Making the public properties `dynamic` will allow customization using [`UIAppearance` proxies](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIAppearance_Protocol/), allowing application-wide customization of some properties.

For example:

    TagListView.appearance().cornerRadius = 5
    TagListView.appearance().borderWidth = 2
    TagListView.appearance().textFont = UIFont.systemFontOfSize(12)
    TagListView.appearance().shadowRadius = 2
    TagListView.appearance().shadowOpacity = 0.4
    TagListView.appearance().shadowColor = UIColor.blackColor()
    TagListView.appearance().shadowOffset = CGSizeMake(1, 1)
    TagListView.appearance().tagBackgroundColor = UIColor(red:0.42, green:0.63, blue:0.92, alpha:1)
    TagListView.appearance().tagSelectedBackgroundColor = UIColor.redColor()
    TagListView.appearance().borderColor = UIColor(red:0, green:0.57, blue:1, alpha:1)
    TagListView.appearance().paddingY = 5
    TagListView.appearance().paddingX = 15
    TagListView.appearance().marginY = 10
    TagListView.appearance().marginX = 10
    TagListView.appearance().removeButtonIconSize = 7
    TagListView.appearance().removeIconLineWidth = 2
    TagListView.appearance().removeIconLineColor = UIColor(red: 1, green: 1, blue: 1, alpha: 0.6)
    TagListView.appearance().enableRemoveButton = true

Will render this:

![Render result](http://i.imgur.com/rjZJuXB.png)