### PR TITLE
Fixes #43 - Invalidate intrinsic content size on rearrange of views

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -269,6 +269,8 @@ public class TagListView: UIView {
             currentRowView.frame.size.height = max(tagViewHeight, currentRowView.frame.height)
         }
         rows = currentRow
+        
+        invalidateIntrinsicContentSize()
     }
     
     // MARK: - Manage tags


### PR DESCRIPTION
When the views are rearranged, we need to invalidate the existing intrinsic content size of the TagListView to update sizing elsewhere.

This fixes #43 but updating the size of the TagListView when it is updated with new data, forcing the self sizing cells to correctly resize.